### PR TITLE
fix cart: emptying a guest/authed cart could silently restore the rem…

### DIFF
--- a/ui/e2e/cart.spec.ts
+++ b/ui/e2e/cart.spec.ts
@@ -2,7 +2,7 @@
 // End-to-end tests for the cart flow.
 
 import { test, expect } from "@playwright/test";
-import { getLocalCartCount, clearSession, setupApiMocks } from "./helpers";
+import { addFirstProductToCart, clearSession, setupApiMocks } from "./helpers";
 
 test.describe("Cart", () => {
   test.beforeEach(async ({ page }) => {
@@ -12,35 +12,20 @@ test.describe("Cart", () => {
   });
 
   test("add to cart from catalog increases cart count", async ({ page }) => {
-    // Find a product with a visible Add to Cart button
-    const addBtn = page.getByRole("button", { name: /add to cart/i }).first();
-    await expect(addBtn).toBeVisible({ timeout: 10_000 });
-
-    const countBefore = await getLocalCartCount(page);
-    await addBtn.click();
-    await page.waitForTimeout(800); // allow cart toast + storage write
-
-    const countAfter = await getLocalCartCount(page);
-    expect(countAfter).toBeGreaterThan(countBefore);
+    await addFirstProductToCart(page);
   });
 
   test("cart page shows added items", async ({ page }) => {
-    // Add a product
-    const addBtn = page.getByRole("button", { name: /add to cart/i }).first();
-    await expect(addBtn).toBeVisible({ timeout: 10_000 });
-    await addBtn.click();
-    await page.waitForTimeout(600);
+    await addFirstProductToCart(page);
 
     // Navigate to cart
     await page.goto("/cart");
     // Either shows item or empty-state — should not crash
     await expect(page.locator("body")).not.toContainText("Something went wrong");
-    // If cart is not empty, we should see at least one article
+
+    // The item we just added must be visible.
     const items = page.locator("article");
-    const count = await items.count();
-    if (count > 0) {
-      await expect(items.first()).toBeVisible();
-    }
+    await expect(items.first()).toBeVisible();
   });
 
   test("cart empty state has a go-shopping link", async ({ page }) => {
@@ -59,43 +44,35 @@ test.describe("Cart", () => {
   });
 
   test("remove button removes an item from the cart", async ({ page }) => {
-    // Add a product first
-    const addBtn = page.getByRole("button", { name: /add to cart/i }).first();
-    await expect(addBtn).toBeVisible({ timeout: 10_000 });
-    await addBtn.click();
-    await page.waitForTimeout(600);
+    await addFirstProductToCart(page);
 
     await page.goto("/cart");
     const removeBtn = page.getByRole("button", { name: /remove/i }).first();
-    const hasRemoveBtn = await removeBtn.isVisible().catch(() => false);
+    await expect(removeBtn).toBeVisible();
 
-    if (hasRemoveBtn) {
-      const itemsBefore = await page.locator("article").count();
-      await removeBtn.click();
-      await page.waitForTimeout(600);
-      const itemsAfter = await page.locator("article").count();
-      expect(itemsAfter).toBeLessThan(itemsBefore);
-    }
+    const itemsBefore = await page.locator("article").count();
+    await removeBtn.click();
+    await page.waitForTimeout(600);
+    const itemsAfter = await page.locator("article").count();
+    expect(itemsAfter).toBeLessThan(itemsBefore);
   });
 
   test("quantity stepper increments qty", async ({ page }) => {
-    const addBtn = page.getByRole("button", { name: /add to cart/i }).first();
-    await expect(addBtn).toBeVisible({ timeout: 10_000 });
-    await addBtn.click();
-    await page.waitForTimeout(600);
+    await addFirstProductToCart(page);
 
     await page.goto("/cart");
 
     const incBtn = page.getByRole("button", { name: /increase quantity|\+/i }).first();
-    const hasIncBtn = await incBtn.isVisible().catch(() => false);
+    await expect(incBtn).toBeVisible();
 
-    if (hasIncBtn) {
-      const qtyInput = page.getByLabel(/quantity/i).first();
-      const qtyBefore = Number(await qtyInput.inputValue());
-      await incBtn.click();
-      await page.waitForTimeout(400);
-      const qtyAfter = Number(await qtyInput.inputValue());
-      expect(qtyAfter).toBe(qtyBefore + 1);
-    }
+    // getByLabel(/quantity/i) also matches the "Increase/Decrease quantity"
+    // buttons since it substring-matches accessible names; scope to the
+    // textbox role so we only ever get the actual <input aria-label="Quantity">.
+    const qtyInput = page.getByRole("textbox", { name: "Quantity" }).first();
+    const qtyBefore = Number(await qtyInput.inputValue());
+    await incBtn.click();
+    await page.waitForTimeout(400);
+    const qtyAfter = Number(await qtyInput.inputValue());
+    expect(qtyAfter).toBe(qtyBefore + 1);
   });
 });

--- a/ui/e2e/helpers.ts
+++ b/ui/e2e/helpers.ts
@@ -1,7 +1,7 @@
 // ui/e2e/helpers.ts
 // Shared helpers for all E2E specs.
 
-import type { Page } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 
 // ── Auth ──────────────────────────────────────────────────────────────────────
 
@@ -86,6 +86,37 @@ export async function getLocalCartCount(page: Page): Promise<number> {
       return 0;
     }
   });
+}
+
+/**
+ * Click the first "Add to cart" button and wait for the local cart count to
+ * actually increase, polling instead of sleeping a fixed amount.
+ *
+ * The catalog swaps the button for a qty stepper immediately after a
+ * successful add. On a loaded CI runner a click can occasionally land right
+ * as that DOM swap happens, so the click never reaches a handler. Retrying
+ * the click a couple of times (each backed by a poll, not a blind sleep)
+ * absorbs that render race without weakening the assertion.
+ */
+export async function addFirstProductToCart(page: Page): Promise<void> {
+  const addBtn = page.getByRole("button", { name: /add to cart/i }).first();
+  await expect(addBtn).toBeVisible({ timeout: 10_000 });
+
+  const countBefore = await getLocalCartCount(page);
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await page.getByRole("button", { name: /add to cart/i }).first().click();
+    try {
+      await expect
+        .poll(() => getLocalCartCount(page), { timeout: 2_000 })
+        .toBeGreaterThan(countBefore);
+      return;
+    } catch {
+      // Button may have been mid-swap; retry.
+    }
+  }
+
+  throw new Error("Add to cart did not increase the local cart count after 3 attempts");
 }
 
 // ── API mocks ─────────────────────────────────────────────────────────────────

--- a/ui/src/pages/Cart.tsx
+++ b/ui/src/pages/Cart.tsx
@@ -595,8 +595,10 @@ export default function Cart() {
 
   const isMountedRef = useRef(true);
   const activeRequestIdRef = useRef(0);
-  const lastMirroredServerSigRef = useRef("");
-  const lastPersistedGuestSigRef = useRef("");
+  // null (not "") sentinel so the very first persist of an emptied cart
+  // (whose signature is also "") isn't mistaken for "unchanged, skip write".
+  const lastMirroredServerSigRef = useRef<string | null>(null);
+  const lastPersistedGuestSigRef = useRef<string | null>(null);
   const focusedQtyKeyRef = useRef<string | null>(null);
   const qtyNoteTimersRef = useRef<Record<string, number>>({});
 


### PR DESCRIPTION
…oved item

The guest/server cart-sync dedupe refs started as "", which collides with the signature of an emptied cart ("") on the very first persist. Removing the last item would skip the localStorage write, and the cart:updated listener would immediately re-read the stale (non-empty) snapshot back into state — the item you just removed would reappear.

Also hardened the cart e2e tests: add-to-cart now polls the actual cart count with retries instead of a blind sleep-then-check (was masking a CI-only click/render race), the remove/qty-stepper/cart-page tests no longer wrap their assertions in silent if-guards that skip on failure, and the qty input selector no longer collides with the increase/decrease quantity buttons.